### PR TITLE
feat(member): Implement soft delete for members with product validation

### DIFF
--- a/src/members/members.controller.ts
+++ b/src/members/members.controller.ts
@@ -67,6 +67,6 @@ export class MembersController {
 
   @Delete(':id')
   remove(@Param('id', ParseMongoIdPipe) id: ObjectId) {
-    return this.membersService.softDelete(id);
+    return this.membersService.softDeleteMember(id);
   }
 }


### PR DESCRIPTION
Added validation to check if a member has recoverable products before soft deletion. 
  If recoverable products are assigned, the deletion is blocked with an appropriate message.
- Implemented logic to mark non-recoverable products as 'Deprecated' and set their 'isDeleted' status to true.